### PR TITLE
Expose MicroNetwork and mocks through cocoapods

### DIFF
--- a/MicroNetwork.podspec
+++ b/MicroNetwork.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |spec|
+  spec.name         			= "MicroNetwork"
+  spec.version      			= "0.1.0"
+  spec.summary      			= "Small micro-framework with abstractions over default iOS networking"
+  spec.homepage     			= "https://github.com/lexorus/MicroNetwork"
+  spec.license      			= "MIT"
+  spec.author       			= { "Dmitrii Celpan" => "celpand@gmail.com" }
+  spec.platform     			= :ios
+  spec.swift_version 			= "5.0"
+  spec.ios.deployment_target  	= "10.0"
+  spec.source 					= { :git => "https://github.com/lexorus/MicroNetwork.git", :tag => "#{spec.version}" }
+  spec.source_files  			= "MicroNetwork/Sources/**/*.swift"
+end

--- a/MicroNetwork.podspec
+++ b/MicroNetwork.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         			= "MicroNetwork"
-  spec.version      			= "0.1.0"
+  spec.version      			= "0.2.0"
   spec.summary      			= "Small micro-framework with abstractions over default iOS networking"
   spec.homepage     			= "https://github.com/lexorus/MicroNetwork"
   spec.license      			= "MIT"

--- a/MicroNetwork.xcodeproj/project.pbxproj
+++ b/MicroNetwork.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetworkMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -444,7 +444,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetworkMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -591,7 +591,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetwork;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -617,7 +617,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetwork;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/MicroNetwork.xcodeproj/project.pbxproj
+++ b/MicroNetwork.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetworkMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -443,6 +444,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetworkMocks;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -589,6 +591,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetwork;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -614,6 +617,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lexorus.MicroNetwork;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/MicroNetwork/SupportingFiles/Info.plist
+++ b/MicroNetwork/SupportingFiles/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MicroNetworkMocks.podspec
+++ b/MicroNetworkMocks.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |spec|
+  spec.name                     = "MicroNetworkMocks"
+  spec.version                  = "0.1.0"
+  spec.summary                  = "Mocks for MicroNetwork."
+  spec.homepage                 = "https://github.com/lexorus/MicroNetwork"
+  spec.license                  = "MIT"
+  spec.author                   = { "Dmitrii Celpan" => "celpand@gmail.com" }
+  spec.platform                 = :ios
+  spec.swift_version 			      = "5.0"
+  spec.ios.deployment_target  	= "10.0"
+  spec.source                   = { :git => "https://github.com/lexorus/MicroNetwork.git", :tag => "#{spec.version}" }
+  spec.source_files             = "MicroNetworkMocks/Sources/**/*.swift"
+  spec.dependency               "MicroNetwork"
+end

--- a/MicroNetworkMocks.podspec
+++ b/MicroNetworkMocks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name                     = "MicroNetworkMocks"
-  spec.version                  = "0.1.0"
+  spec.version                  = "0.2.0"
   spec.summary                  = "Mocks for MicroNetwork."
   spec.homepage                 = "https://github.com/lexorus/MicroNetwork"
   spec.license                  = "MIT"

--- a/MicroNetworkMocks/SupportingFiles/Info.plist
+++ b/MicroNetworkMocks/SupportingFiles/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
### Background
In order to use this framework in a project that manages dependencies through cocoapods, this integration should happen.

### What has been done
1. Add podspec for MicroNetwork
2. Add podspec for MicroNetworkMocks
3. Bump version to 0.2.0

### How to test
1. You can run `pod spec lint` to check the `podspecs` on you machine
2. The framework will also be integrated into a small iOS app: https://github.com/lexorus/flickr-search/tree/refactor/photos-api
