### PR TITLE
Add implicit task resuming for Network

### DIFF
--- a/MicroNetwork/Sources/Core/Network.swift
+++ b/MicroNetwork/Sources/Core/Network.swift
@@ -12,7 +12,7 @@ extension URLSession: Network {
     @discardableResult
     public func dataTask(with url: URLRequest,
                          completion: @escaping NetworkResult<Data>) -> NetworkTask {
-        return dataTask(with: url) { (data, response, error) in
+        let task = dataTask(with: url) { (data, response, error) in
             if (error as NSError?)?.code == NSURLErrorCancelled { return }
             if let response = response as? HTTPURLResponse,
                 !response.statusCode.isSuccessStatusCode {
@@ -22,5 +22,8 @@ extension URLSession: Network {
             guard let data = data else { return completion(.failure(.noDataError)) }
             completion(.success(data))
         }
+        task.resume()
+
+        return task
     }
 }


### PR DESCRIPTION
### Background
The `Network` abstraction should be easy to use from the outside. That's why we shouldn't bother the use of the framework `resuming` the tasks.

### What has been done
1. Add implicit task resuming for Network

### How to test
1. Since the framework does not contain any integration tests yet, this change can only be tested from the integration side, or within the `playground`. Make sure the task is automatically resumed on call.
