### PR TITLE
Add bump version GitHub Actions workflow

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,42 @@
+name: Bump Version
+
+# Documentation with macOS virtual environment:
+# https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
+
+on: [push]
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_11.3.app/Contents/Developer
+
+jobs:
+  Bump_version:
+    name: Bump Version
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: 'master'
+
+      - name: Bump version
+        # fastlane is by default installed on macOS runners
+        run: |
+          bundle install
+          bundle exec fastlane bump_version
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Bump version
+          title: Bump version
+          assignees: lexorus
+          branch: bump-version
+
+      - name: Delete branch
+        if: failure()
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches: ${{ env.BRANCH }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -3,7 +3,9 @@ name: Bump Version
 # Documentation with macOS virtual environment:
 # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
 
-on: [push]
+on:
+  release:
+    types: [published]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_11.3.app/Contents/Developer


### PR DESCRIPTION
### Background
To reduce redundant work of bumping version and creating PR I decided to automate it through Github Actions workflow. It will just open PR though, to keep the things under control.

### What has been done
Add bump version GitHub Actions workflow

### How to test
Not sure how to test this without modifying the actual workflow triggering event.
So, because of this, to test it, let's trigger the event on push, and check if the PR will be created at all. 
After we will make sure that it works on push, let's merge it and test in the wild.
