### PR TITLE
Update bundler version 2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   fastlane
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -20,7 +20,7 @@ or alternatively using `brew cask install fastlane`
 ```
 fastlane ios bump_version
 ```
-Bumps version of the project targets and podspecs
+Bumps versions of the project targets and podspecs
 
 ----
 


### PR DESCRIPTION
### Background
Let's use the latest available bundler version.

### What has been done
Update bundler version 2.1.4

### How to test
1. Run
```ruby
bundler install
bundle update --bundler
```
2. No changes should appear
