### PR TITLE
Move bump version branch name into env variable

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -15,6 +15,9 @@ jobs:
     name: Bump Version
     runs-on: macos-latest
 
+    env:
+      BRANCH: bump-version
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -34,7 +37,7 @@ jobs:
           commit-message: Bump version
           title: Bump version
           assignees: lexorus
-          branch: bump-version
+          branch: ${{ env.BRANCH }}
 
       - name: Delete branch
         if: failure()


### PR DESCRIPTION
### Background
This was previously done but accidentally removed. To avoid branch name duplication (in create PR and delete branch steps), we should create a variable that will represent that name.

### What has been done
Move bump version branch name into env variable

### How to test
Check that 'bump-version' is not hardcoded anywhere in workflow anymore.
